### PR TITLE
build_flatbuffer field arguments coalesced, Support for Additional Root Fields

### DIFF
--- a/.idea/runConfigurations/Test.xml
+++ b/.idea/runConfigurations/Test.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test --package rust_flatbuffer_macros --test unittests -- tests" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_flatbuffer_macros"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2024"
 license-file = "LICENSE"
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A useful Rust macro that defines other Rust macros.
 * Provides an example of using Rust's [variadic](https://doc.rust-lang.org/rust-by-example/macros/variadics.html) macro syntax.
 * An example of meta-coding (i.e., code that generates code)
 
+# Installation
+
+In cargo.toml
+```toml
+[dependencies]
+rust_flatbuffer_macros = { git = "https://github.com/andrewofc/rust_flatbuffer_macros" }
+```
+
 # FlatBuffers
 
 [FlatBuffers](https://flatbuffers.dev) is a cross platform serialization library that provides performance and 
@@ -85,7 +93,7 @@ fn build2() {
 
 ```
 
-# Internals (nuts&bolts)
+# Internals (nuts&amp;bolts)
 
 The power of Rust macros comes from the ability to interact with the compiler
 as code is being compiled.  The compiler will pass a macro syntatical elements that 
@@ -104,11 +112,11 @@ Here is one piece(arm) the 'engine' that this macro is built upon:
 
 ```rust
 macro_rules! build_flatbuffer {
-($builder:expr, $typ:ident, $($field:ident = $value:expr),* ) => {
+    ($builder:expr, $typ:ty, $($field:ident $(= $value:expr)?),+ ) => {
         {
         paste::paste! {
         let args = [<$typ Args>] {
-            $($field: $value,)*
+            $($field $(: $value)?,)*
             ..[<$typ Args>]::default()
         } ;
         $typ::create($builder, &args)
@@ -119,14 +127,14 @@ macro_rules! build_flatbuffer {
 
 * $builder - is the [FlatBufferBuilder](https://docs.rs/flatbuffers/latest/flatbuffers/struct.FlatBufferBuilder.html) and is a macro! type 'expr'(i.e., a piece of rust syntax that is a valid expression)
 * $typ - is the flatbuffer struct name
-* $field - of type 'ident' (i.e., a valid rust identifier)
-* $value - is the expression to be assigned to the field.
+* $field - of type 'ident' (i.e., a valid rust identifier), possibly a local variable
+* $value - is the expression to be assigned to the field if there is no local.
 
 The [paste!](https://docs.rs/paste/latest/paste/#more-elaborate-example) macro will expand the
 [<$typ Args>] piece and turn AddRequest into AddRequestArgs.
 
-The $($field:ident = $value:expr),* accepts one or more field value pairs, separated by an '='.  Then the
-$($field: $value,)* will expand to the "field: value" pairs within the AddRequestArgs 
+The $($field:ident $(= $value:expr)?)* accepts one or more local variable or  field&amp;value pairs, 
+separated by an '='.  Then the macro will expand to the "variable" or "field: value" pairs within the AddRequestArgs 
 definition.  
 
 When we apply this macro to:
@@ -153,20 +161,19 @@ leverages rusts ability to incorporate local variables that match field names to
 a the Args struct.
 
 ```rust
-let addend_a = 2 ;
-let addend_b = 3 ;
-let b = build_flatbuffer!(&mut builder, AddRequest, addend_a, addend_b);
+    let addend_a = 2;
+    let addend_b = 3;
+    let b = build_flatbuffer!(&mut builder, AddRequest, addend_a, addend_b);
 ```
 Which expands to:
 ```rust
- {
+ 
         let args = AddRequestArgs {
             addend_a: a,
             addend_b: b,
             ..AddRequestArgs::default()
         };
         AddRequest::create((&mut builder), &args)
-}
 ```
 
 ## Outer Macro
@@ -213,6 +220,31 @@ macro_rules! flatbuffer_builderbuilder {
 }
 ```
 
+# Addtional Root Fields
+Extending the original example:
+```flatbuffers
+
+union Payload {
+    AddRequest,
+    MultiplyRequest,
+}
+table Message {
+    payload: Payload ;
+    extra_field1: int32 ;
+    extra_field2: int32 ;
+}
+
+root_type Message ;
+```
+
+The extra fields can be added with a variant of the macro:
+```rust
+
+let b = build_flatbuffer!(&mut builder, extra_field1=0, extra_field2=2 => AddRequest, addend_a, addend_b);
+```
+
+The '=>' separates the root fields from the populating of the inner fields of the union member.
+
 # Troubleshooting
 
 If we don't use the $DOLLAR token we get the following error:
@@ -222,4 +254,44 @@ error: attempted to repeat an expression containing no syntax variables matched 
    --> /Users/andrew/projects/rustserver2/rust_flatbuffer_macros/src/lib.rs:123:55
     |
 123 |                     ($builder:expr, $bodytype:ident, $($field:ident),* ) => {{
+```
+
+
+# flatc setup
+
+The flatc version with ubuntu and other distros sometimes lags
+behind the one in use with rust's flatbuffers-build crate.  If
+so carefully check the version of the flatbuffers-build crate, it will
+typically reference the version of flatc in use (e.g v25.12.19)
+
+## Building
+To build the appropriate version:
+
+```bash
+mkdir tmp
+cd tmp
+git clone https://github.com/google/flatbuffers.git
+cd flatbuffers
+git checkout v25.12.19
+mkdir release
+cd release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/flatbuffers ..
+make -j `nproc`
+sudo make install
+export PATH=/opt/flatbuffers/bin:$PATH # possibly adding it to your profile
+```
+
+## In build.rs
+
+```rust 
+    // Compile the schemas.
+    // NOTE: For multiple schemas, the order can matter if there are dependencies.
+    // For simple cases, iterating over the directory contents is often sufficient.
+    BuilderOptions::new_with_files(&fbs_files)
+        .set_compiler("/opt/flatbuffers/bin/flatc")
+        .set_output_path("./tests/fb")
+        .add_flatc_arguments(&["--reflect-types", "--rust-module-root-file"])
+        .compile()
+        .expect("FlatBuffers compilation failed");
+
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 // MIT License
 //
 // Copyright (c) 2026 Andrew Ellis Page
@@ -60,7 +61,7 @@
 #[macro_export]
 macro_rules! build_flatbuffer {
 
-   ($builder:expr, $typ:ident) => {
+   ($builder:expr, $typ:ty) => {
         {
             paste::paste! {
                 let args = [<$typ Args>]::default() ;
@@ -69,22 +70,11 @@ macro_rules! build_flatbuffer {
         }
     } ;
 
-($builder:expr, $typ:ident, $($field:ident = $value:expr),* ) => {
+    ($builder:expr, $typ:ty, $($field:ident $(= $value:expr)?),+ ) => {
         {
         paste::paste! {
         let args = [<$typ Args>] {
-            $($field: $value,)*
-            ..[<$typ Args>]::default()
-        } ;
-        $typ::create($builder, &args)
-        } }
-    } ;
-
-    ($builder:expr, $typ:ident, $($field:ident),* ) => {
-        {
-        paste::paste! {
-        let args = [<$typ Args>] {
-            $($field,)*
+            $($field $(: $value)?,)*
             ..[<$typ Args>]::default()
         } ;
         $typ::create($builder, &args)
@@ -94,7 +84,7 @@ macro_rules! build_flatbuffer {
 
 #[macro_export]
 macro_rules! flatbuffer_builderbuilder {
-    ($DOLLAR:tt $root:ident, $union:ident) => {
+    ($DOLLAR:tt $root:ty, $union:ty) => {
         paste::paste! {
             macro_rules! [<build_ $root _buffer>]
                 {
@@ -102,34 +92,39 @@ macro_rules! flatbuffer_builderbuilder {
                         let body = build_flatbuffer!($builder, $bodytype) ;
                         let args = [ <$root Args> ] {
                             [ <$union:snake _type> ]: $union::$bodytype,
-                            [<$union:snake>]: Some(body.as_union_value())
+                            [<$union:snake>]: Some(body.as_union_value()),
+                            ..[<$root Args>]::default()
                         } ;
                         let msg = $root::create($builder, &args) ;
                         $builder.finish_size_prefixed(msg, None);
                         $builder.finished_data()
                         }} ;
 
-                    ($builder:expr, $bodytype:ident, $DOLLAR($field:ident = $value:expr),* ) => {{
-                        let body = build_flatbuffer!($builder, $bodytype, $DOLLAR($field = $value),* );
+                    ($builder:expr, $bodytype:ident, $DOLLAR($field:ident $DOLLAR(= $value:expr)?),+ ) => {{
+                        let body = build_flatbuffer!($builder, $bodytype, $DOLLAR($field $DOLLAR(= $value)?),+ );
                         let args = [ <$root Args> ] {
                             [ <$union:snake _type> ]: $union::$bodytype,
-                            [<$union:snake>]: Some(body.as_union_value())
+                            [<$union:snake>]: Some(body.as_union_value()),
+                            ..[<$root Args>]::default()
                         } ;
                         let msg = $root::create($builder, &args) ;
                         $builder.finish_size_prefixed(msg, None);
                         $builder.finished_data()
                     }} ;
 
-                    ($builder:expr, $bodytype:ident, $DOLLAR($field:ident),* ) => {{
-                        let body = build_flatbuffer!($builder, $bodytype, $DOLLAR($field),* );
+                    ($builder:expr, $DOLLAR($rootfield:ident $DOLLAR(= $rootvalue:expr)?),* => $bodytype:ident, $DOLLAR($field:ident $DOLLAR(= $value:expr)?),+ ) => {{
+                        let body = build_flatbuffer!($builder, $bodytype, $DOLLAR($field $DOLLAR(= $value)?),+ );
                         let args = [ <$root Args> ] {
                             [ <$union:snake _type> ]: $union::$bodytype,
-                            [<$union:snake>]: Some(body.as_union_value())
+                            [<$union:snake>]: Some(body.as_union_value()),
+                            $DOLLAR($rootfield $DOLLAR(: $rootvalue)?,)*
+                            ..[<$root Args>]::default()
                         } ;
                         let msg = $root::create($builder, &args) ;
                         $builder.finish_size_prefixed(msg, None);
                         $builder.finished_data()
                     }} ;
+
                 }
             }
     }

--- a/tests/unittest.fbs
+++ b/tests/unittest.fbs
@@ -27,10 +27,21 @@ table AddRequest {
     addend_b: int32 ;
 }
 
+table AddRequest4 {
+    addend_a: int32 ;
+    addend_b: int32 ;
+    addend_c: int32 ;
+    addend_d: int32 ;
+}
+
+
+
 table MultiplyRequest {
     multiplicand: int32 ;
     mutiplier: int32 ;
 }
+
+
 
 /// Case where struct is empty
 table UnhandledRequest {
@@ -43,6 +54,7 @@ table StringMessage {
 
 union TestMessage {
     AddRequest,
+    AddRequest4,
     MultiplyRequest,
     UnhandledRequest,
     StringMessage,
@@ -50,6 +62,8 @@ union TestMessage {
 
 table UnittestMessage {
     test_message: TestMessage ; // Note fieldname must be same as field name in lowercase
+    serialno: int32 ;
+    extradata: int32 ;
 }
 
 root_type UnittestMessage ;

--- a/tests/unittests.rs
+++ b/tests/unittests.rs
@@ -31,12 +31,16 @@ mod tests {
     use rust_flatbuffer_macros::{build_flatbuffer, flatbuffer_builderbuilder};
 
     flatbuffer_builderbuilder!($ /* note the $ */ UnittestMessage, TestMessage);
+    
+    pub fn quickrand() -> i32 {
+        let mut rng = rand::rng();
+        rng.random_range(-1000..1000)
+    }
 
     #[test]
     pub fn test_fields_builder() {
-        let mut rng = rand::rng();
-        let a = rng.random_range(-1000..1000);
-        let b = rng.random_range(-1000..1000);
+        let a = quickrand();
+        let b = quickrand();
 
         let mut builder = flatbuffers::FlatBufferBuilder::new();
         let buf =
@@ -53,9 +57,8 @@ mod tests {
 
     #[test]
     pub fn test_localvars_builder() {
-        let mut rng = rand::rng();
-        let addend_a = rng.random_range(-1000..1000);
-        let addend_b = rng.random_range(-1000..1000);
+        let addend_a = quickrand();
+        let addend_b = quickrand();
 
         let mut builder = flatbuffers::FlatBufferBuilder::new();
 
@@ -99,4 +102,66 @@ mod tests {
         assert_eq!(payload.s1(), Some("foo"));
         assert_eq!(payload.s2(), Some("bar"));
     }
+
+    #[test]
+    pub fn test_4fields_builder() {
+        let mut builder = flatbuffers::FlatBufferBuilder::new();
+        let (addend_a, b, addend_c, d) = (quickrand(),quickrand(),quickrand(),quickrand());
+        let buf = build_UnittestMessage_buffer!(
+            &mut builder,
+            AddRequest4, addend_a, addend_b = b, addend_c, addend_d = d
+        );
+        let rootmessage = flatbuffers::root::<UnittestMessage>(&buf[4..]).unwrap();
+
+        assert!(rootmessage.test_message_type() == TestMessage::AddRequest4);
+        let payload = rootmessage.test_message_as_add_request_4().unwrap();
+
+        assert_eq!(payload.addend_a(), addend_a);
+        assert_eq!(payload.addend_b(), b);
+        assert_eq!(payload.addend_c(), addend_c);
+        assert_eq!(payload.addend_d(), d);
+
+        builder.reset();
+
+        /*
+         * test a different interspersing of fields
+         */
+        let (addend_a, b, c, addend_d) = (quickrand(),quickrand(),quickrand(),quickrand());
+        let buf = build_UnittestMessage_buffer!(
+            &mut builder,
+            AddRequest4,
+            addend_a, addend_b = b, addend_c=c, addend_d) ;
+
+        let rootmessage = flatbuffers::root::<UnittestMessage>(&buf[4..]).unwrap();
+
+        assert!(rootmessage.test_message_type() == TestMessage::AddRequest4);
+        let payload = rootmessage.test_message_as_add_request_4().unwrap();
+
+        assert_eq!(payload.addend_a(), addend_a);
+        assert_eq!(payload.addend_b(), b);
+        assert_eq!(payload.addend_c(), c);
+        assert_eq!(payload.addend_d(), addend_d);
+    }
+
+    #[test]
+    fn test_addtional_root_fields() {
+        let addend_a = quickrand();
+        let addend_b = quickrand();
+        let (serialno, extradata) = (quickrand(), quickrand());
+
+        let mut builder = flatbuffers::FlatBufferBuilder::new();
+
+        let buf = build_UnittestMessage_buffer!(&mut builder, serialno=serialno, extradata => AddRequest, addend_a, addend_b);
+
+        let root_message = flatbuffers::root::<UnittestMessage>(&buf[4..]).unwrap();
+        assert!(root_message.serialno() == serialno);
+        assert!(root_message.extradata() == extradata);
+
+        assert!(root_message.test_message_type() == TestMessage::AddRequest);
+
+        let payload = root_message.test_message_as_add_request().unwrap();
+        assert!(payload.addend_a() == addend_a);
+        assert!(payload.addend_b() == addend_b);
+    }
+
 } // mod


### PR DESCRIPTION
Closes #8

mixing field=expr interspersed with var with field name

README.md touchup
Tuneup to the Cargo.toml manifest
Added no_std for embedded projects

README.md text on adding addtional fields

Updating version
Adding README.md section for flatc setup